### PR TITLE
Support client callback handler class def in sigma config for IAM auth

### DIFF
--- a/confluent-sigma/sigma-streams/src/main/java/io/confluent/sigmarules/rules/SigmaRulesStore.java
+++ b/confluent-sigma/sigma-streams/src/main/java/io/confluent/sigmarules/rules/SigmaRulesStore.java
@@ -66,6 +66,10 @@ public class SigmaRulesStore implements CacheUpdateHandler<String, String> {
             kcacheProps.setProperty("kafkacache.sasl.jaas.config",
                 properties.getProperty("sasl.jaas.config"));
 
+        if (properties.containsKey("sasl.client.callback.handler.class"))
+            kcacheProps.setProperty("kafkacache.sasl.client.callback.handler.class",
+                    properties.getProperty("sasl.client.callback.handler.class"));
+
         if (properties.containsKey(SigmaProperties.SCHEMA_REGISTRY.toString())) {
             kcacheProps.setProperty(KEY_CONVERTER_SCHEMA_REGISTRY_URL,
                 properties.getProperty(SigmaProperties.SCHEMA_REGISTRY.toString()));


### PR DESCRIPTION
### Motivation:

The Confluent Sigma project currently supports SASL/SCRAM authentication. In my specific use-case, we are using Packer to load the sigma jar and the aws-msk-iam-auth jar into the same image. When adding the IAM jar onto the classpath, I tried defining a -Dargument for the sasl.client.callback.handler.class but did not have success.

When adding the property to SigmaRulesStore.java, I was able to pass the configuration into the sigma.properties file, just like the SASL/SCRAM method.

### Justification to the Solution:

I think it would be good to support IAM from the Sigma project as well, to remain consistent with the current support for SASL/SCRAM in the config file.

For example,
```
security.protocol=SASL_SSL
sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required;
sasl.client.callback.handler.class=software.amazon.msk.auth.iam.IAMClientCallbackHandler
sasl.mechanism=AWS_MSK_IAM
```

This now works with IAM auth when loading the aws-msk-iam-auth jar on the classpath.